### PR TITLE
Fix to retrieve more than 100 projects as set as a default by Azure

### DIFF
--- a/AzureDevOps.py
+++ b/AzureDevOps.py
@@ -7,6 +7,9 @@ token_str = ''
 _azure_auth_header = None
 lookback_days = 90
 
+# The top argument from the user (or default to 100)
+top = ''
+
 
 def easy_base_64_encode(original_string):
     original_bytes = bytes(original_string, 'ascii')
@@ -55,9 +58,10 @@ def is_within_90_days(dt_event, dt_now):
 
 # https://docs.microsoft.com/en-us/rest/api/azure/devops/core/projects/list?view=azure-devops-rest-5.0
 # GET https://dev.azure.com/{organization}/_apis/projects?api-version=5.0
-def azure_devops_list_projects(organization):
+# Added the top argument at the end of the URI
+def azure_devops_list_projects(organization, top):
     azure_auth_header = get_azure_auth_header()
-    full_api_url = 'https://dev.azure.com/%s/_apis/projects?api-version=5.0' % organization
+    full_api_url = 'https://dev.azure.com/%s/_apis/projects?api-version=5.0&$top=%s' % (organization, top)
 
     resp = requests.get(full_api_url, headers=azure_auth_header)
     resp_json_obj = resp.json()

--- a/README.md
+++ b/README.md
@@ -6,6 +6,6 @@ Install virtual environment with:
 
 
 Then run the script with:
-`pipenv run python3 azure-repos-contributors-count.py --organization=[Azure DevOps Organization] --username=[Azure DevOps Username] --pat=[Azure DevOps Personal Access Token]`
+`pipenv run python3 azure-repos-contributors-count.py --organization=[Azure DevOps Organization] --username=[Azure DevOps Username] --pat=[Azure DevOps Personal Access Token] --top=[The top n number of projects to retrieve, if not set default is 100]`
 
 (Or use alternate Python 3 environment as required)

--- a/azure-repos-contributors-count.py
+++ b/azure-repos-contributors-count.py
@@ -8,7 +8,7 @@ def parse_command_line_args():
     parser = argparse.ArgumentParser(description="Count developers in Azure Repos active in the last 90 days")
     parser.add_argument('--organization', type=str, help='Your Azure DevOps Organization')
     parser.add_argument('--username', type=str, help='Your Azure DevOps username')
-    parser.add_argument('--pat', type=str, help='Your Azure DevOps Personal Access Token')
+    parser.add_argument('--pat', type=int, help='Your Azure DevOps Personal Access Token')
 
     # Added argument of the n top projects to retieve, default is 100
     parser.add_argument('--top', type=str, help='The top n projects to return')
@@ -39,7 +39,7 @@ def parse_command_line_args():
         print('Number of projects to retrieve was set to 100')
     
     # Set the max of projects to retieve to 100k in order to not stress the server
-    elif int(args.top) > 100000:
+    elif args.top > 100000:
         print('The number of projects to retrieve can not be greater than 100000')
         parser.print_usage()
         parser.print_help()

--- a/azure-repos-contributors-count.py
+++ b/azure-repos-contributors-count.py
@@ -10,6 +10,9 @@ def parse_command_line_args():
     parser.add_argument('--username', type=str, help='Your Azure DevOps username')
     parser.add_argument('--pat', type=str, help='Your Azure DevOps Personal Access Token')
 
+    # Added argument of the n top projects to retieve, default is 100
+    parser.add_argument('--top', type=str, help='The top n projects to return')
+
     args = parser.parse_args()
 
     if args.organization is None:
@@ -30,6 +33,20 @@ def parse_command_line_args():
         parser.print_help()
         quit()
 
+    # Check if the top arg was set, if not set to 100 as default
+    if args.top is None:
+        args.top = 100
+        print('Number of projects to retrieve was set to 100')
+    
+    # Set the max of projects to retieve to 100k in order to not stress the server
+    elif int(args.top) > 100000:
+        print('The number of projects to retrieve can not be greater than 100000')
+        parser.print_usage()
+        parser.print_help()
+        quit()    
+    else :
+        print('Number of projects to retrieve was set to ' ,args.top)
+
     return args
 
 
@@ -37,17 +54,20 @@ args = parse_command_line_args()
 AzureDevOps.username = args.username
 AzureDevOps.token_str = args.pat
 
-projects_response_obj = AzureDevOps.azure_devops_list_projects(args.organization)
+projects_response_obj = AzureDevOps.azure_devops_list_projects(args.organization, args.top)
 # print(test_list_projects_response_json_obj)
 
 dt_utc_now = datetime.datetime.utcnow()
 
 unique_authors = set()
 
+# Accumulated Variable to count the projects retrieved and print the value at the end
+totalProjects = 0
+
 # Across all repos in all projects
 for next_project in projects_response_obj['value']:
     print('project name: %s' % next_project['name'])
-
+    totalProjects += 1
     project_id = next_project['id']
 
     # Get all repos in this project
@@ -83,7 +103,11 @@ for next_project in projects_response_obj['value']:
     print()
 
 print('\n\nUnique authors contributing in the last 90 days:')
+
 for a in unique_authors:
     print(a)
+
+# Print the total of projects retrieved
+print('\n\nTotal Projects found: ', totalProjects)
 
 quit()

--- a/azure-repos-contributors-count.py
+++ b/azure-repos-contributors-count.py
@@ -8,10 +8,10 @@ def parse_command_line_args():
     parser = argparse.ArgumentParser(description="Count developers in Azure Repos active in the last 90 days")
     parser.add_argument('--organization', type=str, help='Your Azure DevOps Organization')
     parser.add_argument('--username', type=str, help='Your Azure DevOps username')
-    parser.add_argument('--pat', type=int, help='Your Azure DevOps Personal Access Token')
+    parser.add_argument('--pat', type=str, help='Your Azure DevOps Personal Access Token')
 
     # Added argument of the n top projects to retieve, default is 100
-    parser.add_argument('--top', type=str, help='The top n projects to return')
+    parser.add_argument('--top', type=int, help='The top n projects to return')
 
     args = parser.parse_args()
 


### PR DESCRIPTION
Azure limits to 100 items in the response, to bypass that, a $top value should be set at the end of the GET call